### PR TITLE
replace gemcutter with rubygems and fix activesupport dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :gemcutter
+source 'https://rubygems.org'
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,20 @@
 PATH
   remote: .
   specs:
-    matlock (0.1.0)
-      active_support (= 3.0.0)
+    matlock (0.1.2)
+      activesupport (= 3.0.0)
       commander (~> 4.1.3)
       mechanize (~> 2.5.1)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    active_support (3.0.0)
-      activesupport (= 3.0.0)
     activesupport (3.0.0)
-    commander (4.1.3)
+    commander (4.1.6)
       highline (~> 1.6.11)
-    domain_name (0.5.7)
-      unf (~> 0.0.3)
-    highline (1.6.15)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
+    highline (1.6.21)
     mechanize (2.5.1)
       domain_name (~> 0.5, >= 0.5.1)
       mime-types (~> 1.17, >= 1.17.2)
@@ -26,20 +24,22 @@ GEM
       ntlm-http (~> 0.1, >= 0.1.1)
       webrobots (~> 0.0, >= 0.0.9)
     metaclass (0.0.1)
-    mime-types (1.19)
+    mime-types (1.25.1)
+    mini_portile (0.6.2)
     minitest (4.3.3)
     mocha (0.13.1)
       metaclass (~> 0.0.1)
-    net-http-digest_auth (1.2.1)
-    net-http-persistent (2.8)
-    nokogiri (1.5.6)
+    net-http-digest_auth (1.4)
+    net-http-persistent (2.9.4)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     ntlm-http (0.1.1)
     rake (10.0.3)
-    unf (0.0.5)
+    unf (0.1.4)
       unf_ext
-    unf_ext (0.0.5)
+    unf_ext (0.0.7.1)
     unindentable (0.1.0)
-    webrobots (0.0.13)
+    webrobots (0.1.1)
 
 PLATFORMS
   ruby

--- a/matlock.gemspec
+++ b/matlock.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('mechanize', '~> 2.5.1')
   s.add_dependency('commander', '~> 4.1.3')
-  s.add_dependency('active_support', '3.0.0')
+  s.add_dependency('activesupport', '3.0.0')
   
   s.add_development_dependency('rake', '~> 10.0.3')
   s.add_development_dependency('minitest', '~> 4.3.3')


### PR DESCRIPTION
-  Swapping out gemcutter for rubygems
-  Replacing `active_support` with `activesupport` per https://github.com/chef/knife-vcloud/issues/5

I also made `stopwords` default to the `common_words.txt` list on https://github.com/indorsely/matlock/blob/master/lib/matlock.rb#L16 but I figured that was a more personal change so I left that on my fork. Thanks for showing me this repo @benbjohnson !
